### PR TITLE
Print "0 <unit>" when scale is zero'd

### DIFF
--- a/usbscale.c
+++ b/usbscale.c
@@ -307,7 +307,7 @@ static int print_scale_data(unsigned char* dat) {
             return -1;
         case 0x02:
             if(status != lastStatus)
-                fprintf(stderr, "Scale is zero'd...\n");
+                printf("%g %s\n", 0, UNITS[unit]);
             break;
         case 0x03:
             if(status != lastStatus)

--- a/usbscale.c
+++ b/usbscale.c
@@ -306,9 +306,9 @@ static int print_scale_data(unsigned char* dat) {
             fprintf(stderr, "Scale reports Fault\n");
             return -1;
         case 0x02:
-            if(status != lastStatus)
-                printf("%g %s\n", 0, UNITS[unit]);
-            break;
+            // Handle "zero value" as any other measurement
+            printf("%g %s\n", 0, UNITS[unit]);
+            return 0;
         case 0x03:
             if(status != lastStatus)
                 fprintf(stderr, "Weighing...\n");


### PR DESCRIPTION
Better to print the actual scale value instead of a different message.
